### PR TITLE
Adding .bowerrc and updating README with documentation on how to contribute

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+  "directory": "bower_components"
+}

--- a/README.md
+++ b/README.md
@@ -33,6 +33,16 @@ Pending:
 
 [Design Doc](https://docs.google.com/document/d/1o069KLuBH4jpwm1FCLZFwKMgM73Xi8_1JyjhSxVpidM/edit?usp=sharing) - Design document for Angular-data.
 
+#### Contributing
+1. Fork the repo
+1. `$ git clone {{yourForkUrl}}`
+1. `$ npm install && bower install && npm test`
+1. Make your changes complete with any applicable tests
+1. `$ npm test` (make sure they pass ;-D)
+1. `$ git commit -am 'A useful commit message'`
+1. `$ git push`
+1. Create PR :-D Thanks!
+
 ## Project Status
 
 | Branch | Master |


### PR DESCRIPTION
The `.bowerrc` is to tell bower to install stuff directly into `bower_components` because by default it installs them in `app/bower_components` and all the tests depend on them being in `bower_components`. Feel free to ask me to make changes to the steps. But those are the steps I took to make this PR and I thought they were reasonable :-)
