### PR TITLE
unlinkInverse: avoid splicing when index is undefined

### DIFF
--- a/src/datastore/sync_methods/unlinkInverse.js
+++ b/src/datastore/sync_methods/unlinkInverse.js
@@ -17,7 +17,9 @@ function _unlinkInverse(definition, linked) {
                     index = i;
                   }
                 });
-                item[def.localField].splice(index, 1);
+                if (index !== undefined) {
+                  item[def.localField].splice(index, 1);
+                }
               } else if (item[def.localField] === linked) {
                 delete item[def.localField];
               }


### PR DESCRIPTION
When I delete a resource, angular-data is also removing references to/from unrelated resources during `_unlinkInverse`.  In these cases, `index` was undefined, which is effectively treated as `0` by splice and would remove an unrelated item.
