### PR TITLE
bower: update bower.json acc to the spec

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,13 +2,12 @@
   "author": "Jason Dobry",
   "name": "angular-data",
   "description": "Data store for Angular.js.",
-  "version": "1.4.2",
   "homepage": "http://angular-data.pseudobry.com/",
   "repository": {
     "type": "git",
     "url": "https://github.com/jmdobry/angular-data.git"
   },
-  "main": "./dist/angular-data.min.js",
+  "main": "./dist/angular-data.js",
   "ignore": [
     ".idea/",
     ".*",


### PR DESCRIPTION
Bower uses git tags and ignores the `version` field.
See https://github.com/bower/bower.json-spec#version
Also according to the same spec, minified files shouldn't be included to `main`.
