### PR TITLE
fix js-data-http dependecy

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -119,7 +119,11 @@ module.exports = function (grunt) {
         },
         module: {
           loaders: [
-            { test: /(.+)\.js$/, loader: 'babel-loader?blacklist=useStrict' }
+            {
+              test: /(.+)\.js$/,
+              exclude: /node_modules/, // exclude any and all files in the node_modules folder
+              loader: 'babel-loader?blacklist=useStrict'
+            }
           ],
           preLoaders: [
             {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 /* jshint loopfunc:true */
 let JSData = require('js-data')
-let DSHttpAdapter = require('../node_modules/js-data-http/src/index.js')
+let DSHttpAdapter = require('js-data-http')
 let angular = require('angular')
 
 let { DSUtils, DSErrors } = JSData


### PR DESCRIPTION
after running `bower install`, the js-data file referenced did not exist.  So I fixed this by referencing the module name directly.  This broke the babel-loader in webpack, so I added an  `exclude: /node_modules/`