### PR TITLE
Upgrade js-data-http to 2.2.4

### DIFF
--- a/scripts/js-data-http.js
+++ b/scripts/js-data-http.js
@@ -1,5 +1,5 @@
 var fs = require('fs')
-var url = 'https://github.com/js-data/js-data-http/archive/2.2.3.tar.gz'
+var url = 'https://github.com/js-data/js-data-http/archive/2.2.4.tar.gz'
 var directory = './.js-data-http/'
 var request = require('request')
 var targz = require('tar.gz')
@@ -16,7 +16,7 @@ try {
   read.pipe(write)
 
   write.on('finish', function () {
-    var copyRead = fs.createReadStream(directory + 'js-data-http-2.2.3/src/index.js')
+    var copyRead = fs.createReadStream(directory + 'js-data-http-2.2.4/src/index.js')
     var copyWrite = fs.createWriteStream('./.js-data-http.js')
     copyRead.pipe(copyWrite)
   })


### PR DESCRIPTION
Uses the fix from js-data/js-data-http#75 in js-data-angular.

- [x] - `npm test` succeeds
- [x] - Pull request has been squashed into 1 commit
- [x] - I did NOT commit changes to `dist/`
- [x] - Code coverage does not decrease (if any source code was changed)
- [x] - Appropriate JSDoc comments were updated in source code (if applicable)
- [x] - Approprate changes to js-data.io docs have been suggested ("Suggest Edits" button)
